### PR TITLE
API-590 fix: don't throw an error when ensuring the user exists

### DIFF
--- a/packages/bot/src/bot.ts
+++ b/packages/bot/src/bot.ts
@@ -132,6 +132,7 @@ export class BotClient {
 async function createUserIfNotExist(userId: string) {
   // First, try to get the user using the users/me endpoint
   const getUserResponse = await getV1UsersMe({
+    throwOnError: false,
     headers: {
       'X-USER-ID': userId,
       'X-USER-ID-TYPE': 'telegram',
@@ -156,6 +157,7 @@ async function createUserIfNotExist(userId: string) {
 
 async function createUser(userId: string) {
   const createUserResponse = await postV1Users({
+    throwOnError: false,
     body: {
       id: userId,
       linkedAccounts: [


### PR DESCRIPTION
[Recent PR](https://github.com/sensay-io/telegram-integration/pull/10) broke the Telegram bot's user authentication flow. The API client now throws errors for non-2xx responses, but the bot expects to check status codes directly (specifically 401) to determine if a user needs to be created.

We never noticed this issue during testing because all the users we tested with already existed.

This PR restores previous behavior for the two authentication-related API requests, allowing the bot to continue checking status codes rather than handling exceptions.
