### PR TITLE
fix: use ctx.api.sendChatAction for reply messages

### DIFF
--- a/packages/bot/src/bot-actions.ts
+++ b/packages/bot/src/bot-actions.ts
@@ -1,12 +1,12 @@
-import { type AutoChatActionFlavor, autoChatAction } from '@grammyjs/auto-chat-action'
-import { type FileFlavor, hydrateFiles } from '@grammyjs/files'
+import { autoChatAction } from '@grammyjs/auto-chat-action'
+import { hydrateFiles } from '@grammyjs/files'
 import { limit } from '@grammyjs/ratelimiter'
 // TODO: Replace @grammyjs/transformer-throttler with @grammyjs/auto-retry
 // @grammyjs/transformer-throttler is unmaintained.
 // The docs recommend using the auto-retry plugin instead:
 // https://grammy.dev/plugins/transformer-throttler
 import { apiThrottler } from '@grammyjs/transformer-throttler'
-import { Bot, type Context } from 'grammy'
+import { Bot } from 'grammy'
 import type { Api, RawApi } from 'grammy'
 import { PRIVATE_CHAT } from './constants'
 import {
@@ -199,7 +199,8 @@ export const botActions = ({
     const needsReply = hasUserRepliedToReplica(reply, botUsername)
     if (!messageText.includes(`@${botUsername}`) && !needsReply && !isPrivateChat) return
 
-    ctx.chatAction = 'typing'
+    // TODO: figure out why ctx.chatAction is not working here
+    ctx.api.sendChatAction(chatId, 'typing')
 
     if (!(await isPlanValid(overridePlan, replicaUuid))) {
       await sendSubscriptionRenewMessage(ctx)

--- a/packages/bot/src/helpers.ts
+++ b/packages/bot/src/helpers.ts
@@ -13,7 +13,7 @@ import { z } from 'zod'
 import { config } from './config'
 import { sendError } from './responses'
 import { PRIVATE_CHAT } from './constants'
-import { TelegramContext } from './types/responses'
+import type { TelegramContext } from './types/responses'
 
 // TODO: API-589 Refactor this file. Move functions to domain-specific files.
 


### PR DESCRIPTION
For some reason `ctx.chatAction = 'typing'` doesn't work in the private/reply message handler. Maybe it's because the top level message handler have the same filter. Bug to investigate: https://linear.app/sensay/issue/API-687/figure-out-why-ctxchataction-=-typing-doesnt-work-in-the-privatereply