### PR TITLE
Auto-revive permanently-failed bots so the fleet self-heals

### DIFF
--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -242,12 +242,23 @@ export class Orchestrator {
       return
     }
 
-    for (const botDefinition of this.botsDefinitions.values()) {
+    for (const botDefinition of Array.from(this.botsDefinitions.values())) {
       try {
-        if (this.botsSupervisors.has(botDefinition.replicaUUID)) {
-          await this.updateBot(botDefinition.replicaUUID, botDefinition.replicaSlug)
-        } else {
+        const existingSupervisor = this.botsSupervisors.get(botDefinition.replicaUUID)
+        if (!existingSupervisor) {
           await this.addBot(botDefinition.replicaUUID, botDefinition.replicaSlug)
+        } else if (existingSupervisor.status === BotStatus.FAILED) {
+          // A bot that has exhausted its restart attempts stays FAILED indefinitely:
+          // updateBot() is a no-op when the definition is unchanged, so the supervisor is
+          // never revived and the bot silently stops responding (no polling, no error).
+          // Recreate it here so every reload cycle gives a permanently-failed bot a fresh
+          // start with the attempt counter reset, letting the fleet self-heal without a
+          // manual service restart.
+          this.logger.warn(`Reviving failed bot ${botDefinition.replicaSlug}`)
+          await this.deleteBotUnchecked(botDefinition.replicaUUID)
+          await this.addBotUnchecked(botDefinition)
+        } else {
+          await this.updateBot(botDefinition.replicaUUID, botDefinition.replicaSlug)
         }
       } catch (error) {
         this.logger.error(error as Error, `Failed to reload bot ${botDefinition.replicaSlug}`)


### PR DESCRIPTION
## What & why

When a bot worker exhausts `maxFailedStartAttempts`, its `BotSupervisor` is permanently `FAILED`. The 60s reload loop (`reloadBotsDefinitions`) only calls `updateBot()` for existing supervisors, which is a **no-op when the replica definition is unchanged** — so a `FAILED` bot is never revived. It silently stops polling Telegram with **no error**, and the only fix is a manual full-service restart.

This bit us in production (Jun 2026): the orchestrator had **~171 days uptime** with bots decayed into `failed`/silently-dead. A `railway restart` recovered 44/46 bots — but nothing would have recovered them automatically.

## Change

In the reload loop, if an existing supervisor's status is `FAILED`, recreate it (delete + add) so it gets a fresh supervisor with the attempt counter reset. Any permanently-failed bot now **self-heals within one reload interval (~60s)** instead of needing a manual restart. Healthy/running bots are unaffected (still go through `updateBot`). Also snapshots the definitions map before iterating, since the revive path mutates it.

## Notes / follow-ups
- The two remaining prod failures (`korra`, `markpregelj`) are **revoked Telegram tokens** — they need fresh BotFather tokens; this change will keep retrying them every ~60s (harmless, but worth fixing/removing).
- Worth a separate hardening pass: a polling-loop handler so a transient `getUpdates` 409 doesn't crash the worker via `unhandledRejection` in the first place, and an alert when `/health` is `unhealthy` (the health check can't currently detect "alive but not polling").

## Testing
- `tsc --noEmit`: clean (no new type errors).
- `biome check` on the file: clean for the change (one unrelated pre-existing format nit elsewhere in the file).
- The new code only triggers for `FAILED` supervisors, so the existing happy-path test is unaffected; behavior is identical to `main` with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)