### PR TITLE
Fix Railway build: drop redundant nested @sentry/cli + guard install scripts

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+# Install all packages WITHOUT running lifecycle scripts, then run them via `npm rebuild`
+# once the full dependency tree is on disk.
+#
+# Works around npm behaviour on Railway's build image where a package's install script
+# runs before its own dependency is linked. Specifically, @sentry/cli (pulled in
+# transitively by @sentry/esbuild-plugin) `require()`s `https-proxy-agent` at the top of
+# its install script and crashes `npm ci` with "Cannot find module 'https-proxy-agent'".
+# Running the scripts after the tree is complete makes resolution reliable. esbuild and
+# @biomejs/biome native binaries are set up by `npm rebuild` as well.
+[phases.install]
+cmds = ["npm ci --ignore-scripts", "npm rebuild"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,135 +2269,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.56.1.tgz",
-      "integrity": "sha512-fNB/Ng11HrkGOSEIDg+fc3zfTCV7q6kJddp6ndK3QlYFsCffRSnclaX1SMp+mqxdWkHqe1kkp85OY8G/x5uAWw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.56.1.tgz",
-      "integrity": "sha512-AypXIwZvOMJb9RgjI/98hTAd06FcOjqjIm6G9IR0OI4pJCOcaAXz9NKXdJqxpZd7phSMJnD+Bx/8iYOUPeY73A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.56.1.tgz",
-      "integrity": "sha512-vnH+WJEsUq7Lf7xc9udzE/M4hoDXXsniFFYr/7BvdnXtCQlNNaWFMXHbEDYAql3baIlHkWoG8cEHWuB/YKyniw==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.56.1.tgz",
-      "integrity": "sha512-3/BlKe5Vdnia36MeovghHJD8lbcum5TFIxLp+PSfH2sVb09+5Jo0L95oRTI2JkD8Fs+QNssvTqTxJj5eIo/n+A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd",
-        "android"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.56.1.tgz",
-      "integrity": "sha512-Gg8RV7CV7Tz4fiR1EN1Af5AVhJsnEXiZvfvfQXI4lp51MKAhcxZIMtEfg9HaWsn3Dm/wgwYBinyeywfWbTXYDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.56.1.tgz",
-      "integrity": "sha512-6u6a060yC3i76Ze1apqgWr5luQSyhuD5ND84eWfh/UbddsEa42UHjoVHOiBwmpZqf/hvNZAtzLnE4NCvU4zOMg==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.56.1.tgz",
-      "integrity": "sha512-11cdflajBrDWlRZqI9MOu7ok2vnPzFjKmbU3YvBYWQapNE+HHAsWdsRL/u/P1RmU62vj7Y42iSUcj6x1SNrdPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@sentry/cli/node_modules/@sentry/cli-linux-arm": {
       "version": "2.42.2",
       "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.42.2.tgz",
@@ -6381,51 +6252,6 @@
         }
       }
     },
-    "packages/node_modules/@sentry/cli": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.56.1.tgz",
-      "integrity": "sha512-VDAIg+gmjNtJS5VUZQMDSK9RaKC9hYQi3PoXpNa+owNfQNk60bCi8z8jkbWRcKbNGn3V51WqvrQAqLoNAdPc9w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@sentry/cli-darwin": "2.56.1",
-        "@sentry/cli-linux-arm": "2.56.1",
-        "@sentry/cli-linux-arm64": "2.56.1",
-        "@sentry/cli-linux-i686": "2.56.1",
-        "@sentry/cli-linux-x64": "2.56.1",
-        "@sentry/cli-win32-arm64": "2.56.1",
-        "@sentry/cli-win32-i686": "2.56.1",
-        "@sentry/cli-win32-x64": "2.56.1"
-      }
-    },
-    "packages/node_modules/@sentry/cli-darwin": {
-      "version": "2.56.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.56.1.tgz",
-      "integrity": "sha512-zfhT8MrvB5x/xRdIVGwg+sG0Cx3i0G6RH2zCrdQ/moWn8TfkwsM0O1k/AxpwbpcRfAHCkVb04CU/yKciKwg2KA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/node_modules/@sentry/types": {
       "version": "9.13.0",
       "dev": true,
@@ -6658,7 +6484,6 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.7.0",
-        "@sentry/cli": "^2.56.1",
         "@sentry/esbuild-plugin": "^3.3.1",
         "@sentry/types": "^9.12.0",
         "@types/node": "^22.13.11",

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -15,8 +15,7 @@
     "node": "22.x"
   },
   "scripts": {
-    "build": "node esbuild.config.mjs && (npm run sentry:upload-sourcemaps || echo 'Sentry source map upload failed, continuing...')",
-    "sentry:upload-sourcemaps": "sentry-cli sourcemaps upload --org sensay-io --project telegram-integration --release $RAILWAY_GIT_COMMIT_SHA --rewrite --url-prefix '/var/task/telegram-integration' ./dist",
+    "build": "node esbuild.config.mjs",
     "start": "node --env-file-if-exists=.env.local dist/index.js",
     "dev": "npm run dev:bun",
     "dev:bun": "bun run --env-file=.env.local --watch src/index.ts",
@@ -42,7 +41,6 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.7.0",
-    "@sentry/cli": "^2.56.1",
     "@sentry/esbuild-plugin": "^3.3.1",
     "@sentry/types": "^9.12.0",
     "@types/node": "^22.13.11",


### PR DESCRIPTION
## Problem
Deploys fail at `npm ci` (build never reaches app code):
```
npm error path /app/packages/node_modules/@sentry/cli
npm error Error: Cannot find module 'https-proxy-agent'  (scripts/install.js:14)
```
`@sentry/cli`'s install script `require()`s `https-proxy-agent` at module top. The failing copy is the **nested** `packages/node_modules/@sentry/cli@2.56.1` (the orchestrator's own devDep). On Railway's npm, that nested workspace package's install script can't resolve the root-hoisted `https-proxy-agent` — confirmed it persists even with `npm ci --ignore-scripts && npm rebuild` while the nested copy exists. (Newer npm resolves it fine, which is why a local `npm ci` passes — this is environment/toolchain drift, not a source change.)

## Why this happens now, with no code change
Last deploy was Nov 2025; this is the first build since. Railway's build image / npm drifted, and a cold build (cache evicted) exposed a latent fragility in how `@sentry/cli`'s install script resolves its dep when installed as a nested workspace copy.

## Fix
1. **Remove the orchestrator's direct `@sentry/cli` devDep + the `sentry:upload-sourcemaps` script.** It was redundant — `@sentry/esbuild-plugin` already uploads sourcemaps during the build. This eliminates the nested copy entirely. The only remaining `@sentry/cli` is the root copy pulled transitively by the esbuild plugin, which sits next to `https-proxy-agent` at root `node_modules` and resolves reliably.
2. **Add `nixpacks.toml`** that installs with `--ignore-scripts` then runs `npm rebuild`, so install scripts run after the full tree is on disk (defence-in-depth for this ordering class; also sets up esbuild/biome native binaries).

`package.json` change is just the removed devDep + script; the lockfile shrinks by removing the nested `@sentry/cli` subtree.

## Verification (local)
- `npm ci --ignore-scripts && npm rebuild` → exit 0 (`rebuilt dependencies successfully`).
- `npm run build` → exit 0, all `dist` artifacts produced.
- `@sentry/cli` and `https-proxy-agent` now both at root `node_modules` (sibling resolution).

Unblocks the deploy of the already-merged #35 self-heal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)