### PR TITLE
Build with npm 11 to fix npm-workspaces hoisting on Railway

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,11 +1,8 @@
-# Install all packages WITHOUT running lifecycle scripts, then run them via `npm rebuild`
-# once the full dependency tree is on disk.
-#
-# Works around npm behaviour on Railway's build image where a package's install script
-# runs before its own dependency is linked. Specifically, @sentry/cli (pulled in
-# transitively by @sentry/esbuild-plugin) `require()`s `https-proxy-agent` at the top of
-# its install script and crashes `npm ci` with "Cannot find module 'https-proxy-agent'".
-# Running the scripts after the tree is complete makes resolution reliable. esbuild and
-# @biomejs/biome native binaries are set up by `npm rebuild` as well.
+# Railway's default build image ships npm 10, whose npm-workspaces hoisting/resolution
+# leaves nested packages and sibling workspaces unable to resolve ROOT-hoisted
+# dependencies during install/build — e.g. @sentry/cli -> https-proxy-agent (crashes
+# `npm ci`), and packages/shared -> esbuild (crashes the build with ERR_MODULE_NOT_FOUND).
+# npm 11 hoists/links these correctly (verified: a full clean `npm ci` + `npm run build`
+# succeeds on npm 11). Upgrade npm before installing. Node version is unchanged (22.x).
 [phases.install]
-cmds = ["npm ci --ignore-scripts", "npm rebuild"]
+cmds = ["npm install -g npm@11 && npm ci"]


### PR DESCRIPTION
Railway's build image ships **npm 10**, whose workspace hoisting/resolution prevents nested packages and sibling workspaces from resolving root-hoisted deps during install/build:
- `@sentry/cli` → `https-proxy-agent` (crashed `npm ci`)
- `packages/shared` → `esbuild` (crashed the build: `ERR_MODULE_NOT_FOUND`)

**npm 11 resolves both** — a full clean `npm ci` + `npm run build` succeeds on npm 11 locally. This upgrades npm in the Nixpacks install phase (`npm install -g npm@11 && npm ci`); Node stays 22.x. Final piece to unblock the deploy (after #36 lockfile fix and #37 redundant-dep removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)